### PR TITLE
✨ Improve getCountryName function

### DIFF
--- a/components/SelectedYearDetails/SelectedYearDetails.tsx
+++ b/components/SelectedYearDetails/SelectedYearDetails.tsx
@@ -10,10 +10,10 @@ import {
 import { Bar } from "react-chartjs-2";
 import { InternMap } from "d3";
 import { FC } from "react";
-import { NeCountriesTopoJson } from "../../types/NeTopoJson";
 import getCountryName from "../../lib/getCountryName";
 import resolveConfig from "tailwindcss/resolveConfig";
 import tailwindConfig from "../../tailwind.config";
+import { Country } from "@prisma/client";
 
 ChartJS.register(
   CategoryScale,
@@ -30,13 +30,13 @@ type Props = {
     year: string;
     countries: InternMap<string, number>;
   }[];
-  neCountriesTopoJson: NeCountriesTopoJson;
+  countries: Country[];
 };
 
 const SelectedYearDetails: FC<Props> = ({
   selectedYear,
   projectsByYearCountry,
-  neCountriesTopoJson,
+  countries,
 }) => {
   const options = {
     indexAxis: "y" as const,
@@ -56,7 +56,7 @@ const SelectedYearDetails: FC<Props> = ({
 
   const labels = Array.from(
     selectedYearCountries ? selectedYearCountries.keys() : [],
-  ).map((d) => getCountryName(d, neCountriesTopoJson));
+  ).map((d) => getCountryName(d, countries));
 
   const data = {
     labels,

--- a/components/SpaceTimeCubeProjects/SpaceTimeCubeProjects.tsx
+++ b/components/SpaceTimeCubeProjects/SpaceTimeCubeProjects.tsx
@@ -21,15 +21,18 @@ import TimelineControl from "../TimelineControl";
 import Tooltip from "../Tooltip";
 import SelectedProjectsDetails from "./SelectedProjectsDetails";
 import useProjectEvents from "./useProjectEvents.hook";
+import { Country } from "@prisma/client";
 
 type Props = {
   projects: ProjectsWithCountries;
   neCountriesTopoJson: NeCountriesTopoJson;
+  countries: Country[];
 };
 
 const SpaceTimeCubeProjects: FC<Props> = ({
   projects,
   neCountriesTopoJson,
+  countries,
 }) => {
   const [selectedCountries, setSelectedCountries] = useState<
     FeatureIdentifier[]
@@ -155,7 +158,7 @@ const SpaceTimeCubeProjects: FC<Props> = ({
                       <SelectedYearDetails
                         selectedYear={selectedYear}
                         projectsByYearCountry={projectsByYearCountry}
-                        neCountriesTopoJson={neCountriesTopoJson}
+                        countries={countries}
                       />
                     )}
                   </>

--- a/components/visuals/charts/BtorsByYear.tsx
+++ b/components/visuals/charts/BtorsByYear.tsx
@@ -1,18 +1,18 @@
-import { FC, useMemo } from "react";
-import useMeasure from "react-use-measure";
+import { Country } from "@prisma/client";
+import { Group } from "@visx/group";
 import { ScaleOrdinal, format, max, min, scaleLinear, union } from "d3";
+import { FC, useMemo } from "react";
+import { MdArrowUpward, MdInfoOutline } from "react-icons/md";
+import useMeasure from "react-use-measure";
 import { BtorsGroupedByYear } from "../../../lib/data/queries/btors/getBtorsGroupedByYear";
+import getCountryName from "../../../lib/getCountryName";
+import { DutchCabinet } from "../../../types/DutchCabinet";
 import AxisX from "../../AxisX";
 import AxisY from "../../AxisY";
-import RuleY from "../../RuleY";
-import { MdArrowUpward, MdInfoOutline } from "react-icons/md";
-import { DutchCabinet } from "../../../types/DutchCabinet";
-import { BhosCountryWithCategories } from "../BtorsAndCabinets";
 import LinePath from "../../LinePath/LinePath";
-import { Group } from "@visx/group";
-import { NeCountriesTopoJson } from "../../../types/NeTopoJson";
-import getCountryName from "../../../lib/getCountryName";
 import { getFilledSeries } from "../../LinePath/LinePath.helpers";
+import RuleY from "../../RuleY";
+import { BhosCountryWithCategories } from "../BtorsAndCabinets";
 
 type Props = {
   btors: BtorsGroupedByYear;
@@ -21,7 +21,7 @@ type Props = {
   colorScale: ScaleOrdinal<string, string>;
   bhosCountries: BhosCountryWithCategories[];
   mouseEnterLeaveHandler: (isoAlpha3?: string) => void;
-  neCountries: NeCountriesTopoJson;
+  countries: Country[];
 };
 
 const BtorsByYear: FC<Props> = ({
@@ -31,7 +31,7 @@ const BtorsByYear: FC<Props> = ({
   mouseEnterLeaveHandler,
   colorScale,
   bhosCountries,
-  neCountries,
+  countries,
 }) => {
   const [chartRef, { width }] = useMeasure();
 
@@ -84,8 +84,8 @@ const BtorsByYear: FC<Props> = ({
   }, [btors, margin, width]);
 
   const activeCountryName = useMemo(
-    () => getCountryName(activeCountry ?? "", neCountries),
-    [activeCountry, neCountries],
+    () => getCountryName(activeCountry ?? "", countries),
+    [activeCountry, countries],
   );
 
   const hasNoTravelData = useMemo(

--- a/components/visuals/maps/BtorsByYear.tsx
+++ b/components/visuals/maps/BtorsByYear.tsx
@@ -1,3 +1,4 @@
+import { Country } from "@prisma/client";
 import { Group } from "@visx/group";
 import { groups, max, min, scaleLinear } from "d3";
 import { FC, useState } from "react";
@@ -5,20 +6,21 @@ import { Vector2 } from "three";
 import getCentroidByIsoCode from "../../../lib/data/getCentroidByIsoCode";
 import { BtorsGroupedByYear } from "../../../lib/data/queries/btors/getBtorsGroupedByYear";
 import getCountryName from "../../../lib/getCountryName";
-import { NeCountriesTopoJson } from "../../../types/NeTopoJson";
 import LinePath from "../../LinePath/";
 import { getFilledSeries } from "../../LinePath/LinePath.helpers";
 import MapLayerBase from "../../MapLayerBase";
 import { useMapLayoutContext } from "../../MapLayout/MapLayoutContext";
+import { NeCountriesTopoJson } from "../../../types/NeTopoJson";
 
 type Props = {
+  countries: Country[];
   neCountries: NeCountriesTopoJson;
   btors: BtorsGroupedByYear;
 };
 
-const BtorsByYear: FC<Props> = ({ btors, neCountries }) => {
+const BtorsByYear: FC<Props> = ({ btors, countries, neCountries }) => {
   const [selectedCountry, setSelectedCountry] = useState<string | undefined>(
-    undefined
+    undefined,
   );
 
   const chartWidth = 40;
@@ -42,7 +44,7 @@ const BtorsByYear: FC<Props> = ({ btors, neCountries }) => {
   };
 
   const hasCentroid = (
-    btor: BtorCountryWithValidCentroid | BtorCountry
+    btor: BtorCountryWithValidCentroid | BtorCountry,
   ): btor is BtorCountryWithValidCentroid => {
     return btor.centroid?.x !== undefined && btor.centroid?.y !== undefined;
   };
@@ -70,7 +72,7 @@ const BtorsByYear: FC<Props> = ({ btors, neCountries }) => {
           (d) => d.year,
           (d) => d.count,
           minTime,
-          maxTime
+          maxTime,
         );
         return (
           <g key={d.isoAlpha3} transform={`translate(${x} ${y})`}>
@@ -91,7 +93,7 @@ const BtorsByYear: FC<Props> = ({ btors, neCountries }) => {
                 xScale={xScale}
                 yScale={yScale}
                 identifier={d.isoAlpha3}
-                label={getCountryName(d.isoAlpha3, neCountries)}
+                label={getCountryName(d.isoAlpha3, countries)}
                 mouseEnterLeaveHandler={(isoAlpha3?: string) => {
                   setSelectedCountry(isoAlpha3);
                 }}

--- a/lib/getCountryName.ts
+++ b/lib/getCountryName.ts
@@ -1,24 +1,8 @@
-import { NeCountriesTopoJson } from "../types/NeTopoJson";
+import { Country } from "@prisma/client";
 
-const getCountryName = (isoCode: string, countries: NeCountriesTopoJson) => {
-  switch (isoCode) {
-    case "GIB": {
-      return "Gibraltar";
-      break;
-    }
-    case "SJM": {
-      return "Svalbard and Jan Mayen";
-      break;
-    }
-    case "REU": {
-      return "Réunion";
-      break;
-    }
-  }
-  const country = countries.objects.ne_admin_0_countries.geometries
-    .map((d) => d.properties)
-    .find((d) => d?.ADM0_A3_NL === isoCode || d?.ISO_A3 == isoCode);
-  return country ? country.NAME_EN : `${isoCode} (no matching country)`;
+const getCountryName = (isoCode: string, countries: Country[]) => {
+  const country = countries.find((d) => d?.isoAlpha3 === isoCode);
+  return country ? country.nameLongEn : `${isoCode} (no matching country)`;
 };
 
 export default getCountryName;

--- a/lib/getCountryName.ts
+++ b/lib/getCountryName.ts
@@ -1,9 +1,23 @@
 import { NeCountriesTopoJson } from "../types/NeTopoJson";
 
 const getCountryName = (isoCode: string, countries: NeCountriesTopoJson) => {
+  switch (isoCode) {
+    case "GIB": {
+      return "Gibraltar";
+      break;
+    }
+    case "SJM": {
+      return "Svalbard and Jan Mayen";
+      break;
+    }
+    case "REU": {
+      return "Réunion";
+      break;
+    }
+  }
   const country = countries.objects.ne_admin_0_countries.geometries
     .map((d) => d.properties)
-    .find((d) => d?.ADM0_A3_NL === isoCode);
+    .find((d) => d?.ADM0_A3_NL === isoCode || d?.ISO_A3 == isoCode);
   return country ? country.NAME_EN : `${isoCode} (no matching country)`;
 };
 

--- a/pages/applicants/origin-country.tsx
+++ b/pages/applicants/origin-country.tsx
@@ -133,10 +133,10 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
   ]);
 
   const timeseries = [
-    { label: getCountryName("CHN", neCountriesTopoJson), data: china },
-    { label: getCountryName("NLD", neCountriesTopoJson), data: netherlands },
-    { label: getCountryName("IND", neCountriesTopoJson), data: india },
-    { label: getCountryName("KEN", neCountriesTopoJson), data: kenya },
+    { label: getCountryName("CHN", countries), data: china },
+    { label: getCountryName("NLD", countries), data: netherlands },
+    { label: getCountryName("IND", countries), data: india },
+    { label: getCountryName("KEN", countries), data: kenya },
   ].map(({ label, data }) => {
     return {
       label,

--- a/pages/employees/origin.tsx
+++ b/pages/employees/origin.tsx
@@ -14,13 +14,11 @@ import getCountryWithEmployeeCount, {
   CountryWithEmployeeCount,
 } from "../../lib/data/queries/country/getCountryWithEmployeeCount";
 import prisma from "../../prisma/client";
-import { NeCountriesTopoJson } from "../../types/NeTopoJson";
 import { SharedPageProps } from "../../types/Props";
 import Container from "../../components/Container";
 
 type Props = {
   countryWithEmployeeCount: CountryWithEmployeeCount;
-  neCountriesTopoJson: NeCountriesTopoJson;
   countries: Country[];
 } & SharedPageProps;
 

--- a/pages/introduction/travels.tsx
+++ b/pages/introduction/travels.tsx
@@ -29,7 +29,6 @@ import getBtorsGroupedByYear, {
 import getCountryCodes from "../../lib/data/queries/country/getCountryCodes";
 import { BhosCountry } from "../../types/BhosCountry";
 import { DutchCabinet } from "../../types/DutchCabinet";
-import { NeCountriesTopoJson } from "../../types/NeTopoJson";
 import { SharedPageProps } from "../../types/Props";
 import Section from "../../components/Section";
 import getDepartments from "../../lib/data/queries/departments/getDepartments";
@@ -42,7 +41,6 @@ type Props = SharedPageProps & {
   bhosCountries: BhosCountry[];
   btorsByDepartment: BtorsGroupedByRegionByDepartment;
   dutchCabinets: DutchCabinet[];
-  neCountriesTopoJson: NeCountriesTopoJson;
   departments: Department[];
 };
 
@@ -59,7 +57,11 @@ const Page: NextPage<Props> = ({
 }) => {
   const heroVisual = (
     <MapLayoutFluid projection={geoBertin1953()}>
-      <BtorsByYearMap neCountries={neCountriesTopoJson} btors={btorsByYear} />
+      <BtorsByYearMap
+        countries={countries}
+        neCountries={neCountriesTopoJson}
+        btors={btorsByYear}
+      />
     </MapLayoutFluid>
   );
 
@@ -120,6 +122,7 @@ const Page: NextPage<Props> = ({
           <div className="mt-5">
             <BtorsAndCabinets
               neCountries={neCountriesTopoJson}
+              countries={countries}
               bhosCountries={bhosCountries}
               btorsByYear={btorsByYear}
               dutchCabinets={dutchCabinets}
@@ -137,6 +140,7 @@ const Page: NextPage<Props> = ({
           <div className="mt-5">
             <MapLayoutFluid projection={geoBertin1953()} extent={extent}>
               <BtorsByYearMap
+                countries={countries}
                 neCountries={neCountriesTopoJson}
                 btors={btorsByYear}
               />

--- a/pages/playground/maplayoutfluid-test.tsx
+++ b/pages/playground/maplayoutfluid-test.tsx
@@ -21,7 +21,11 @@ import Container from "../../components/Container";
 
 type Props = { btorsByYear: BtorsGroupedByYear } & SharedPageProps;
 
-const Page: NextPage<Props> = ({ neCountriesTopoJson, btorsByYear }) => {
+const Page: NextPage<Props> = ({
+  neCountriesTopoJson,
+  countries,
+  btorsByYear,
+}) => {
   const extent: ExtendedFeature = {
     type: "Feature",
     geometry: {
@@ -61,6 +65,7 @@ const Page: NextPage<Props> = ({ neCountriesTopoJson, btorsByYear }) => {
           <MapLayoutFluid projection={geoBertin1953()} extent={extent}>
             <BtorsByYearMap
               neCountries={neCountriesTopoJson}
+              countries={countries}
               btors={btorsByYear}
             />
           </MapLayoutFluid>
@@ -71,6 +76,7 @@ const Page: NextPage<Props> = ({ neCountriesTopoJson, btorsByYear }) => {
         <Section>
           <MapLayoutFluid projection={geoEquirectangular()} extent={extent}>
             <BtorsByYearMap
+              countries={countries}
               neCountries={neCountriesTopoJson}
               btors={btorsByYear}
             />

--- a/pages/projects/projects-spacetimecube.tsx
+++ b/pages/projects/projects-spacetimecube.tsx
@@ -17,6 +17,7 @@ type Props = SharedPageProps & {
 const ProjectSpaceTimeCube: NextPage<Props> = ({
   neCountriesTopoJson,
   projects,
+  countries,
 }) => {
   return (
     <PageBase title="Projects Space Time Cube">
@@ -25,6 +26,7 @@ const ProjectSpaceTimeCube: NextPage<Props> = ({
           <SpaceTimeCubeProjects
             projects={projects}
             neCountriesTopoJson={neCountriesTopoJson}
+            countries={countries}
           />
         </Section>
       </Container>
@@ -36,7 +38,7 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
   const [projects, countries, neCountriesTopoJson] = await Promise.all([
     getProjectsWithCountries(),
     getCountryCodes(),
-    getCountries("50m"),
+    getCountries(),
   ]);
 
   return {

--- a/pages/projects/projects-spacetimecube.tsx
+++ b/pages/projects/projects-spacetimecube.tsx
@@ -36,7 +36,7 @@ export const getStaticProps: GetStaticProps<Props> = async () => {
   const [projects, countries, neCountriesTopoJson] = await Promise.all([
     getProjectsWithCountries(),
     getCountryCodes(),
-    getCountries(),
+    getCountries("50m"),
   ]);
 
   return {

--- a/types/NeTopoJson.ts
+++ b/types/NeTopoJson.ts
@@ -10,6 +10,7 @@ export type NeScales = "10m" | "50m" | "110m";
 export type CountryProperties = {
   NAME_EN: string;
   NAME_NL: string;
+  ISO_A3: string;
   ADM0_A3_NL: string;
   ADM0_A3: string;
   ADM0_ISO: string;


### PR DESCRIPTION
Hi Jakob, this issue cost me the time much more than i think......
Actually, for the three TopoJson file: ne_110m_admin_0_countries, ne_50m_admin_0_countries, ne_10m_admin_0_countries have 177, 242, 258 countries/regions respectively, so i try replace TopoJson file in the projects-spacetimecube page to get more records. It do works for some countries/regions, but still have two (**REU and SJM**) are missing in the ne_10m_admin_0_countries TopoJson file, even i have look this file in details, the two are still missing.  
At the same time, if we load the ne_10m_admin_0_countries to the SpaceTimeCube, it will report error like:
![44af5bcde9ac8ac6c646ca41967f796](https://github.com/jakoblistabarth/itc-atlas/assets/122973203/fb76b163-8122-44bc-93f5-63c43ed36222)
 While for the the other(110m and 50m) will not have this error, i guess due to this scale is too small and some of the geometry can't get the position so the base map of SpaceTimeCube fail to generate.  So I choose the 50m TopoJson, while in 50m TopoJson, "**GIB**" record is missing........ 
In the end, i use the 'stupid' way to add these 3(**REU, GIB, SJM**) record in getCountryName function. finally, i have to mention is that for some countries/regions iso_code is equal to the ISO_A3, not to the ADM0_A3_NL , and i think ISO_A3 is the standard ISO code, so i add this to the type NeTopoJson. 