### PR TITLE
:children_crossing: Add tooltip to flights map

### DIFF
--- a/components/Flights/Flights.tsx
+++ b/components/Flights/Flights.tsx
@@ -90,11 +90,11 @@ const Flights: FC<Props> = ({ odMatrix, neCountriesTopoJson }) => {
   return (
     <div>
       <MapLayoutFluid projection={geoBertin1953()}>
+        <Targets />
         <FlightsFlowMap
           odMatrix={odMatrix}
           neCountriesTopoJson={neCountriesTopoJson}
         />
-        <Targets />
       </MapLayoutFluid>
       <Tour steps={steps} />
       {/* TODO: implement tour restarting */}

--- a/components/MapLayerFlow/MapLayerFlow.tsx
+++ b/components/MapLayerFlow/MapLayerFlow.tsx
@@ -4,6 +4,9 @@ import { OdMatrix } from "../../types/OdMatrix";
 import MarkCircle from "../MarkCircle";
 import Flow, { FlowStyleProps } from "../MarkFlow";
 import MarkerArrowHead from "../MarkerArrowHead";
+import Tooltip from "../Tooltip";
+import KPI from "../KPI";
+import { HiArrowRight } from "react-icons/hi";
 
 export type FlowPointStyleProps = Omit<
   ComponentProps<typeof MarkCircle>,
@@ -32,21 +35,51 @@ const MapLayerFlow: FC<Props> = ({
         />
       </defs>
       {data.points.features.map((feature) => (
-        <MarkCircle
-          key={feature.properties.name}
-          longitude={feature.geometry.coordinates[0]}
-          latitude={feature.geometry.coordinates[1]}
-          radius={1}
-          {...pointStyle}
-        />
+        <Tooltip.Root key={feature.id}>
+          <Tooltip.Content>
+            <p>
+              Airport:{" "}
+              <span className="font-bold">{feature.properties.name}</span>
+            </p>
+          </Tooltip.Content>
+          <Tooltip.Trigger asChild>
+            <g>
+              <MarkCircle
+                key={feature.properties.name}
+                longitude={feature.geometry.coordinates[0]}
+                latitude={feature.geometry.coordinates[1]}
+                radius={1}
+                {...pointStyle}
+              />
+            </g>
+          </Tooltip.Trigger>
+        </Tooltip.Root>
       ))}
       {data.flows.features.map((feature) => (
-        <Flow
-          key={feature.properties.od}
-          datum={feature}
-          strokeWidthScale={scaleWidth}
-          {...flowStyle}
-        />
+        <Tooltip.Root key={feature.id} followCursor>
+          <Tooltip.Content>
+            <div>
+              <div className="flex items-center gap-1">
+                <span className="font-bold">{feature.properties.o}</span>{" "}
+                <HiArrowRight />{" "}
+                <span className="font-bold">{feature.properties.d}</span>
+              </div>
+              <br />
+              <KPI number={feature.properties.value} unit={"travels"} />
+              <p>in 2019</p>
+            </div>
+          </Tooltip.Content>
+          <Tooltip.Trigger asChild>
+            <g>
+              <Flow
+                key={feature.properties.od}
+                datum={feature}
+                strokeWidthScale={scaleWidth}
+                {...flowStyle}
+              />
+            </g>
+          </Tooltip.Trigger>
+        </Tooltip.Root>
       ))}
     </g>
   );


### PR DESCRIPTION
Hi Jakob, i cost a lot of time to find the reason why tooltip not work if we add them directly. Finally, i think the target of Flight2D is the reason, since in the previous codes, the target was added after the map, so it's kind like the multiple layer-stacking. In that case, if we add tooltip to the map, the target will cover them and make it can't work, so i change the render order of the target and map. (target rendering first, in this case the shapes of target will be covered by the map, but it works if we click button to tour, i think this is fine since we focus on the map). 
The tooltip is added for each circle and flow, i think this is most direct way but we can also use only one tooltip to do that (like Flights3D).
Welcome any suggestions, thanks in advance!